### PR TITLE
[DOCS] Fix broken LND command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Your node should now be set up to connect to Shango. The next step is to send ov
  echo -e "$(curl -s ipinfo.io/ip),\n$(xxd -p -c2000 ~/.lnd/data/chain/bitcoin/$NETWORK/admin.macaroon)," > qr.txt && qrencode -t ANSIUTF8 < qr.txt
 ```
 * On the Shango App, go to 'Settings' -> 'Connect to other LND Servers', and scan the QR code provided
-* Make sure you can connect to your node using the ```lncli connect --rpcserver=<YOUR PUBLIC IP> getinfo``` command first before trying to connect to Shango. 
+* Make sure you can connect to your node using the ```lncli --rpcserver=<YOUR PUBLIC IP> getinfo``` command first before trying to connect to Shango. 
  
 
 


### PR DESCRIPTION
_lncli connect_ is used for connecting your LND node with other nodes.
What you really want to do in the given example is just calling a (getinfo-)command on a remote node. This won't work with the command "connect", instead just use:
`lncli --rpcserver=<ip> <command>`